### PR TITLE
Replace potentially heap information with a stack related

### DIFF
--- a/xml/System/Span`1.xml
+++ b/xml/System/Span`1.xml
@@ -52,7 +52,7 @@
 `Span<T>` is a [ref struct](/dotnet/csharp/language-reference/builtin-types/struct#ref-struct) that is allocated on the stack rather than on the managed heap. Ref struct types have a number of restrictions to ensure that they cannot be promoted to the managed heap, including that they can't be boxed, they can't be assigned to variables of type <xref:System.Object>, `dynamic` or to any interface type, they can't be fields in a reference type, and they can't be used across `await` and `yield` boundaries. In addition, calls to two methods, <xref:System.Span%601.Equals(System.Object)> and <xref:System.Span%601.GetHashCode%2A>, throw a <xref:System.NotSupportedException>. 
 
 > [!IMPORTANT]
-> Because it is a stack-only type, `Span<T>` is unsuitable for many scenarios that require storing references to buffers on the heap. This is true, for example, of routines that make asynchronous method calls. For such scenarios, you can use the complementary <xref:System.Memory%601?displayProperty=nameWithType> and <xref:System.ReadOnlyMemory%601?displayProperty=nameWithType> types.
+> Because it is a stack-only type, `Span<T>` is suitable only for scenarios that preserves their execution to a current stack. This is not true, for example, of routines that make asynchronous method calls. For such scenarios, you can use the complementary <xref:System.Memory%601?displayProperty=nameWithType> and <xref:System.ReadOnlyMemory%601?displayProperty=nameWithType> types.
 
 For spans that represent immutable or read-only structures, use <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>.
 


### PR DESCRIPTION
## Summary

This PR changes the way Span is described in regards to asynchronous flows. Previously it stated that `Span<T>`

> is unsuitable for many scenarios that require storing references to buffers on the heap

Which with different ways of allocating memory and wrapping it with a custom `MemoryPool`/`IMemoryOwner`/`Memory` might not be true.

The new version focuses on preserving the stack, leaving details of the memory allocation to the memory.

I'm not sure that my English is good enough for doco, but I'd be happy to apply any changes if needed to keep these two concerns separated.

